### PR TITLE
添加爆米花机模块

### DIFF
--- a/modular_z121/code/modules/Company_imports/interns_project_emporium.dm
+++ b/modular_z121/code/modules/Company_imports/interns_project_emporium.dm
@@ -66,6 +66,11 @@
 	item_type = /obj/item/ammo_box/magazine/strzelec/starts_empty
 	cost = PAYCHECK_CREW
 
+//  模块
+/datum/armament_entry/company_import/intern_project/modules/popcorndispenser
+	item_type = /obj/item/mod/module/dispenser/popcorn
+	cost = PAYCHECK_CREW
+
 //	杂项
 /datum/armament_entry/company_import/intern_project/misc
 	subcategory = "杂项"

--- a/modular_z121/code/modules/modsuit/popcorndispenser.dm
+++ b/modular_z121/code/modules/modsuit/popcorndispenser.dm
@@ -1,0 +1,8 @@
+/obj/item/mod/module/dispenser/popcorn
+	name = "爆米花机模块"
+	desc = "由汉堡分配器原型逆向工程的稀有技术。\
+这可以从模块服的电池中汲取令人难以置信的力量，在佩戴者\
+中产生可食用的有机物，然而研究似乎完全止步于爆米花。"
+	icon_state = "dispenser"
+	incompatible_modules = list(/obj/item/mod/module/dispenser/popcorn)
+	dispense_type = /obj/item/food/popcorn

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9198,4 +9198,5 @@
 #include "modular_nova\modules\xenoarchartifacts\obj\geosample.dm"
 #include "modular_nova\modules\xenoarchartifacts\obj\particle_battery.dm"
 #include "modular_nova\modules\xenoarchartifacts\obj\wave_scanner.dm"
+#include "modular_z121\code\modules\modsuit\popcorndispenser.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9198,5 +9198,4 @@
 #include "modular_nova\modules\xenoarchartifacts\obj\geosample.dm"
 #include "modular_nova\modules\xenoarchartifacts\obj\particle_battery.dm"
 #include "modular_nova\modules\xenoarchartifacts\obj\wave_scanner.dm"
-#include "modular_z121\code\modules\modsuit\popcorndispenser.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- 汉堡分配器的爆米花版本! -->

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: 爆米花机模块
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
