### PR TITLE
修复了狩猎独头弹对一些生物不生效的bug

### DIFF
--- a/modular_nova/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_nova/modules/shotgunrebalance/code/shotgun.dm
@@ -314,7 +314,7 @@
 	if(!isliving(target) || (damage > initial(damage)))
 		return ..()
 	var/mob/living/target_mob = target
-	if(target_mob.mob_biotypes & biotype_we_look_for || istype(target_mob, /mob/living/simple_animal/hostile/megafauna))
+	if(target_mob.mob_biotypes && biotype_we_look_for || istype(target_mob, /mob/living/simple_animal/hostile/megafauna))
 		damage *= biotype_damage_multiplier
 	return ..()
 


### PR DESCRIPTION
之前狩猎独头弹对一些拉瓦兰生物不生效，现在可以正常对拉瓦兰生物造成的伤害了