### PR TITLE
原动能机枪削弱

### DIFF
--- a/modular_z121/code/modules/machinegun_pka/kineticmachinegun.dm
+++ b/modular_z121/code/modules/machinegun_pka/kineticmachinegun.dm
@@ -8,6 +8,7 @@
 	icon_state = "kineticmachinegun"
 	base_icon_state = "kineticmachinegun"
 	inhand_icon_state = "kineticgun"
+	weapon_weight = WEAPON_MEDIUM
 	recharge_time = 3 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/machinegun)
 	max_mod_capacity = 65

--- a/modular_z121/code/modules/machinegun_pka/projectiles.dm
+++ b/modular_z121/code/modules/machinegun_pka/projectiles.dm
@@ -4,6 +4,6 @@
 
 /obj/projectile/kinetic/machinegun
 	name = "serial kinetic force"
-	damage = 20
+	damage = 15
 	range = 3
 	mod_mult = 0.5


### PR DESCRIPTION
削弱了原动能机枪，伤害从20外伤降低至15外伤，且双持无法同时开火