### PR TITLE
AA12更新

### DIFF
--- a/modular_z121/code/modules/weapon_addtion/weapon_addtion.dm
+++ b/modular_z121/code/modules/weapon_addtion/weapon_addtion.dm
@@ -431,7 +431,7 @@
 
 /obj/item/ammo_box/magazine/aa12/drum
 	name = "AA12 弹鼓"
-	desc = "可容纳15发霰弹的弹鼓，容量大的惊人，体积也大的惊人"
+	desc = "可容纳20发霰弹的弹鼓，容量大的惊人，体积也大的惊人"
 
 	icon = 'modular_z121/icons/obj/guns/weapon_addtion/ammo.dmi'
 	icon_state = "aa12_drum"

--- a/modular_z121/code/modules/weapon_addtion/weapon_addtion.dm
+++ b/modular_z121/code/modules/weapon_addtion/weapon_addtion.dm
@@ -431,7 +431,7 @@
 
 /obj/item/ammo_box/magazine/aa12/drum
 	name = "AA12 弹鼓"
-	desc = "可容纳20发霰弹的弹鼓，容量大的惊人，体积也大的惊人"
+	desc = "可容纳15发霰弹的弹鼓，容量大的惊人，体积也大的惊人"
 
 	icon = 'modular_z121/icons/obj/guns/weapon_addtion/ammo.dmi'
 	icon_state = "aa12_drum"
@@ -442,7 +442,7 @@
 
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	caliber = CALIBER_SHOTGUN
-	max_ammo = 20
+	max_ammo = 15
 
 /obj/item/ammo_box/magazine/aa12/drum/starts_empty
 	start_empty = TRUE

--- a/modular_z121/code/modules/weapon_addtion/weapon_addtion.dm
+++ b/modular_z121/code/modules/weapon_addtion/weapon_addtion.dm
@@ -394,7 +394,6 @@
 
 	w_class = WEIGHT_CLASS_HUGE
 	weapon_weight = WEAPON_HEAVY
-	slot_flags = ITEM_SLOT_BACK
 
 	accepted_magazine_type = /obj/item/ammo_box/magazine/aa12
 	spawnwithmagazine = TRUE
@@ -403,9 +402,6 @@
 	fire_delay = 0.5 SECONDS
 	actions_types = list()
 	spread = 0
-
-	//  0.75x 伤害修正
-	projectile_damage_multiplier = 0.75
 
 	//  开膛待击
 	bolt_type = BOLT_TYPE_OPEN
@@ -416,7 +412,7 @@
 
 /obj/item/ammo_box/magazine/aa12
 	name = "AA12 弹匣"
-	desc = "可容纳5发霰弹的弹匣，它看上去有点大"
+	desc = "可容纳8发霰弹的弹匣，它看上去有点大"
 
 	icon = 'modular_z121/icons/obj/guns/weapon_addtion/ammo.dmi'
 	icon_state = "aa12_standard"
@@ -427,7 +423,7 @@
 
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	caliber = CALIBER_SHOTGUN
-	max_ammo = 5
+	max_ammo = 8
 
 /obj/item/ammo_box/magazine/aa12/starts_empty
 	start_empty = TRUE
@@ -446,7 +442,7 @@
 
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	caliber = CALIBER_SHOTGUN
-	max_ammo = 15
+	max_ammo = 20
 
 /obj/item/ammo_box/magazine/aa12/drum/starts_empty
 	start_empty = TRUE


### PR DESCRIPTION
移除了AA12的伤害修正（0.75→1）
将AA12的弹匣载弹量从5提到8
现在AA12无法背到背上了